### PR TITLE
Fix variable typo

### DIFF
--- a/UTIL/cl_utils.lua
+++ b/UTIL/cl_utils.lua
@@ -192,7 +192,7 @@ function UTIL:GetNextSirenTone(current_tone, veh, main_tone, last_pos)
 
 	if last_pos == nil then
 		for i, tone_id in pairs(approved_tones) do
-			if tone_id == tone then
+			if tone_id == current_tone then
 				temp_pos = i
 				break
 			end


### PR DESCRIPTION
On line 195 there's an if statement to check if the tone_id equals "tone", it's supposed to be "current_tone". At the current state, you can only cycle to the second tone and it won't cycle past that, this typo fix allows for regular cycling through.