### PR TITLE
Add third party event to allow for developers to utilize Luxart Data

### DIFF
--- a/UTIL/cl_lvc.lua
+++ b/UTIL/cl_lvc.lua
@@ -331,7 +331,7 @@ BroadcastPlayerVehicleState = function(vehicle)
 			['actv_manu'] = actv_manu,
 			['actv_horn'] = actv_horn
 		}
-		TriggerEvent('lvc:updateThirdParty', update_data)
+		TriggerEvent('lvc:UpdateThirdParty', update_data)
 	end
 end	
 

--- a/UTIL/cl_lvc.lua
+++ b/UTIL/cl_lvc.lua
@@ -66,7 +66,6 @@ state_indic = {}
 state_lxsiren = {}
 state_pwrcall = {}
 state_airmanu = {}
-
 actv_manu = nil
 actv_horn = nil
 
@@ -131,14 +130,14 @@ CreateThread(function()
 	debug_mode = GetResourceMetadata(GetCurrentResourceName(), 'debug_mode', 0) == 'true'
 	TriggerEvent('chat:addSuggestion', Lang:t('command.lock_command'), Lang:t('command.lock_desc'))
 	SetNuiFocus( false )
-	
+
 	UTIL:FixOversizeKeys(SIREN_ASSIGNMENTS)
 	RegisterKeyMaps()
 	STORAGE:SetBackupTable()
 end)
 
 -- Auxiliary Control Handling
---	Handles radio wheel controls and default horn on siren change playback. 
+--	Handles radio wheel controls and default horn on siren change playback.
 CreateThread(function()
 	while true do
 		if player_is_emerg_driver then
@@ -380,6 +379,15 @@ function TogIndicStateForVeh(veh, newstate)
 			SetVehicleIndicatorLights(veh, 1, true) -- L
 		end
 		state_indic[veh] = newstate
+		local updateArray = {
+			['state_lxsiren'] = state_lxsiren,
+			['state_indic'] = state_indic,
+			['state_pwrcall'] = state_pwrcall,
+			['state_airmanu'] = state_airmanu,
+			['actv_manu'] = actv_manu,
+			['actv_horn'] = actv_horn
+		}
+		TriggerEvent('lvc:updateThirdParty', updateArray)
 	end
 end
 
@@ -405,6 +413,15 @@ function SetLxSirenStateForVeh(veh, newstate)
 				TogMuteDfltSrnForVeh(veh, true)
 			end
 			state_lxsiren[veh] = newstate
+			local updateArray = {
+				['state_lxsiren'] = state_lxsiren,
+				['state_indic'] = state_indic,
+				['state_pwrcall'] = state_pwrcall,
+				['state_airmanu'] = state_airmanu,
+				['actv_manu'] = actv_manu,
+				['actv_horn'] = actv_horn
+			}
+			TriggerEvent('lvc:updateThirdParty', updateArray)
 		end
 	end
 end
@@ -423,6 +440,15 @@ function SetPowercallStateForVeh(veh, newstate)
 				PlaySoundFromEntity(snd_pwrcall[veh], SIRENS[newstate].String, veh, SIRENS[newstate].Ref, 0, 0)
 			end
 			state_pwrcall[veh] = newstate
+			local updateArray = {
+				['state_lxsiren'] = state_lxsiren,
+				['state_indic'] = state_indic,
+				['state_pwrcall'] = state_pwrcall,
+				['state_airmanu'] = state_airmanu,
+				['actv_manu'] = actv_manu,
+				['actv_horn'] = actv_horn
+			}
+			TriggerEvent('lvc:updateThirdParty', updateArray)
 		end
 	end
 end
@@ -441,6 +467,15 @@ function SetAirManuStateForVeh(veh, newstate)
 				PlaySoundFromEntity(snd_airmanu[veh], SIRENS[newstate].String, veh, SIRENS[newstate].Ref, 0, 0)
 			end
 			state_airmanu[veh] = newstate
+			local updateArray = {
+				['state_lxsiren'] = state_lxsiren,
+				['state_indic'] = state_indic,
+				['state_pwrcall'] = state_pwrcall,
+				['state_airmanu'] = state_airmanu,
+				['actv_manu'] = actv_manu,
+				['actv_horn'] = actv_horn
+			}
+			TriggerEvent('lvc:updateThirdParty', updateArray)
 		end
 	end
 end

--- a/UTIL/cl_lvc.lua
+++ b/UTIL/cl_lvc.lua
@@ -69,6 +69,8 @@ state_airmanu = {}
 actv_manu = nil
 actv_horn = nil
 
+local update_data = {}
+
 local ind_state_o = 0
 local ind_state_l = 1
 local ind_state_r = 2
@@ -318,6 +320,21 @@ MakeOrdinal = function(number)
 	end
 end
 
+--Broadcast local vehicle state to other resources
+BroadcastPlayerVehicleState = function(vehicle)
+	if veh == vehicle then
+		update_data = {
+			['state_lxsiren'] = state_lxsiren[veh],
+			['state_indic'] = state_indic[veh],
+			['state_pwrcall'] = state_pwrcall[veh],
+			['state_airmanu'] = state_airmanu[veh],
+			['actv_manu'] = actv_manu,
+			['actv_horn'] = actv_horn
+		}
+		TriggerEvent('lvc:updateThirdParty', update_data)
+	end
+end	
+
 ---------------------------------------------------------------------
 local function CleanupSounds()
 	if count_sndclean_timer > delay_sndclean_timer then
@@ -363,119 +380,87 @@ local function CleanupSounds()
 	end
 end
 ---------------------------------------------------------------------
-function TogIndicStateForVeh(veh, newstate)
-	if DoesEntityExist(veh) and not IsEntityDead(veh) then
+function TogIndicStateForVeh(vehicle, newstate)
+	if DoesEntityExist(vehicle) and not IsEntityDead(vehicle) then
 		if newstate == ind_state_o then
-			SetVehicleIndicatorLights(veh, 0, false) -- R
-			SetVehicleIndicatorLights(veh, 1, false) -- L
+			SetVehicleIndicatorLights(vehicle, 0, false) -- R
+			SetVehicleIndicatorLights(vehicle, 1, false) -- L
 		elseif newstate == ind_state_l then
-			SetVehicleIndicatorLights(veh, 0, false) -- R
-			SetVehicleIndicatorLights(veh, 1, true) -- L
+			SetVehicleIndicatorLights(vehicle, 0, false) -- R
+			SetVehicleIndicatorLights(vehicle, 1, true) -- L
 		elseif newstate == ind_state_r then
-			SetVehicleIndicatorLights(veh, 0, true) -- R
-			SetVehicleIndicatorLights(veh, 1, false) -- L
+			SetVehicleIndicatorLights(vehicle, 0, true) -- R
+			SetVehicleIndicatorLights(vehicle, 1, false) -- L
 		elseif newstate == ind_state_h then
-			SetVehicleIndicatorLights(veh, 0, true) -- R
-			SetVehicleIndicatorLights(veh, 1, true) -- L
+			SetVehicleIndicatorLights(vehicle, 0, true) -- R
+			SetVehicleIndicatorLights(vehicle, 1, true) -- L
 		end
-		state_indic[veh] = newstate
-		local updateArray = {
-			['state_lxsiren'] = state_lxsiren,
-			['state_indic'] = state_indic,
-			['state_pwrcall'] = state_pwrcall,
-			['state_airmanu'] = state_airmanu,
-			['actv_manu'] = actv_manu,
-			['actv_horn'] = actv_horn
-		}
-		TriggerEvent('lvc:updateThirdParty', updateArray)
+		state_indic[vehicle] = newstate
+		BroadcastPlayerVehicleState(vehicle)
 	end
 end
 
 ---------------------------------------------------------------------
-function TogMuteDfltSrnForVeh(veh, toggle)
-	if DoesEntityExist(veh) and not IsEntityDead(veh) then
-		DisableVehicleImpactExplosionActivation(veh, toggle)
+function TogMuteDfltSrnForVeh(vehicle, toggle)
+	if DoesEntityExist(vehicle) and not IsEntityDead(vehicle) then
+		DisableVehicleImpactExplosionActivation(vehicle, toggle)
 	end
 end
 
 ---------------------------------------------------------------------
-function SetLxSirenStateForVeh(veh, newstate)
-	if DoesEntityExist(veh) and not IsEntityDead(veh) then
-		if newstate ~= state_lxsiren[veh] and newstate ~= nil then
-			if snd_lxsiren[veh] ~= nil then
-				StopSound(snd_lxsiren[veh])
-				ReleaseSoundId(snd_lxsiren[veh])
-				snd_lxsiren[veh] = nil
+function SetLxSirenStateForVeh(vehicle, newstate)
+	if DoesEntityExist(vehicle) and not IsEntityDead(vehicle) then
+		if newstate ~= state_lxsiren[vehicle] and newstate ~= nil then
+			if snd_lxsiren[vehicle] ~= nil then
+				StopSound(snd_lxsiren[vehicle])
+				ReleaseSoundId(snd_lxsiren[vehicle])
+				snd_lxsiren[vehicle] = nil
 			end
 			if newstate ~= 0 then
-				snd_lxsiren[veh] = GetSoundId()
-				PlaySoundFromEntity(snd_lxsiren[veh], SIRENS[newstate].String, veh, SIRENS[newstate].Ref, 0, 0)
-				TogMuteDfltSrnForVeh(veh, true)
+				snd_lxsiren[vehicle] = GetSoundId()
+				PlaySoundFromEntity(snd_lxsiren[vehicle], SIRENS[newstate].String, vehicle, SIRENS[newstate].Ref, 0, 0)
+				TogMuteDfltSrnForVeh(vehicle, true)
 			end
-			state_lxsiren[veh] = newstate
-			local updateArray = {
-				['state_lxsiren'] = state_lxsiren,
-				['state_indic'] = state_indic,
-				['state_pwrcall'] = state_pwrcall,
-				['state_airmanu'] = state_airmanu,
-				['actv_manu'] = actv_manu,
-				['actv_horn'] = actv_horn
-			}
-			TriggerEvent('lvc:updateThirdParty', updateArray)
+			state_lxsiren[vehicle] = newstate
+			BroadcastPlayerVehicleState(vehicle)
 		end
 	end
 end
 
 ---------------------------------------------------------------------
-function SetPowercallStateForVeh(veh, newstate)
-	if DoesEntityExist(veh) and not IsEntityDead(veh) then
-		if newstate ~= state_pwrcall[veh] and newstate ~= nil then
-			if snd_pwrcall[veh] ~= nil then
-				StopSound(snd_pwrcall[veh])
-				ReleaseSoundId(snd_pwrcall[veh])
-				snd_pwrcall[veh] = nil
+function SetPowercallStateForVeh(vehicle, newstate)
+	if DoesEntityExist(vehicle) and not IsEntityDead(vehicle) then
+		if newstate ~= state_pwrcall[vehicle] and newstate ~= nil then
+			if snd_pwrcall[vehicle] ~= nil then
+				StopSound(snd_pwrcall[vehicle])
+				ReleaseSoundId(snd_pwrcall[vehicle])
+				snd_pwrcall[vehicle] = nil
 			end
 			if newstate ~= 0 then
-				snd_pwrcall[veh] = GetSoundId()
-				PlaySoundFromEntity(snd_pwrcall[veh], SIRENS[newstate].String, veh, SIRENS[newstate].Ref, 0, 0)
+				snd_pwrcall[vehicle] = GetSoundId()
+				PlaySoundFromEntity(snd_pwrcall[vehicle], SIRENS[newstate].String, vehicle, SIRENS[newstate].Ref, 0, 0)
 			end
-			state_pwrcall[veh] = newstate
-			local updateArray = {
-				['state_lxsiren'] = state_lxsiren,
-				['state_indic'] = state_indic,
-				['state_pwrcall'] = state_pwrcall,
-				['state_airmanu'] = state_airmanu,
-				['actv_manu'] = actv_manu,
-				['actv_horn'] = actv_horn
-			}
-			TriggerEvent('lvc:updateThirdParty', updateArray)
+			state_pwrcall[vehicle] = newstate
+			BroadcastPlayerVehicleState(vehicle)
 		end
 	end
 end
 
 ---------------------------------------------------------------------
-function SetAirManuStateForVeh(veh, newstate)
-	if DoesEntityExist(veh) and not IsEntityDead(veh) then
-		if newstate ~= state_airmanu[veh] and newstate ~= nil then
-			if snd_airmanu[veh] ~= nil then
-				StopSound(snd_airmanu[veh])
-				ReleaseSoundId(snd_airmanu[veh])
-				snd_airmanu[veh] = nil
+function SetAirManuStateForVeh(vehicle, newstate)
+	if DoesEntityExist(vehicle) and not IsEntityDead(vehicle) then
+		if newstate ~= state_airmanu[vehicle] and newstate ~= nil then
+			if snd_airmanu[vehicle] ~= nil then
+				StopSound(snd_airmanu[vehicle])
+				ReleaseSoundId(snd_airmanu[vehicle])
+				snd_airmanu[vehicle] = nil
 			end
 			if newstate ~= 0 then
-				snd_airmanu[veh] = GetSoundId()
-				PlaySoundFromEntity(snd_airmanu[veh], SIRENS[newstate].String, veh, SIRENS[newstate].Ref, 0, 0)
+				snd_airmanu[vehicle] = GetSoundId()
+				PlaySoundFromEntity(snd_airmanu[vehicle], SIRENS[newstate].String, vehicle, SIRENS[newstate].Ref, 0, 0)
 			end
-			state_airmanu[veh] = newstate
-			local updateArray = {
-				['state_lxsiren'] = state_lxsiren,
-				['state_indic'] = state_indic,
-				['state_pwrcall'] = state_pwrcall,
-				['state_airmanu'] = state_airmanu,
-				['actv_manu'] = actv_manu,
-				['actv_horn'] = actv_horn
-			}
-			TriggerEvent('lvc:updateThirdParty', updateArray)
+			state_airmanu[vehicle] = newstate
+			BroadcastPlayerVehicleState(vehicle)
 		end
 	end
 end
@@ -490,8 +475,8 @@ AddEventHandler('lvc:TogIndicState_c', function(sender, newstate)
 	if DoesEntityExist(ped_s) and not IsEntityDead(ped_s) then
 		if ped_s ~= GetPlayerPed(-1) then
 			if IsPedInAnyVehicle(ped_s, false) then
-				local veh = GetVehiclePedIsUsing(ped_s)
-				TogIndicStateForVeh(veh, newstate)
+				local vehicle = GetVehiclePedIsUsing(ped_s)
+				TogIndicStateForVeh(vehicle, newstate)
 			end
 		end
 	end
@@ -505,8 +490,8 @@ AddEventHandler('lvc:TogDfltSrnMuted_c', function(sender)
 	if DoesEntityExist(ped_s) and not IsEntityDead(ped_s) then
 		if ped_s ~= GetPlayerPed(-1) then
 			if IsPedInAnyVehicle(ped_s, false) then
-				local veh = GetVehiclePedIsUsing(ped_s)
-				TogMuteDfltSrnForVeh(veh, true)
+				local vehicle = GetVehiclePedIsUsing(ped_s)
+				TogMuteDfltSrnForVeh(vehicle, true)
 			end
 		end
 	end
@@ -520,8 +505,8 @@ AddEventHandler('lvc:SetLxSirenState_c', function(sender, newstate)
 	if DoesEntityExist(ped_s) and not IsEntityDead(ped_s) then
 		if ped_s ~= GetPlayerPed(-1) then
 			if IsPedInAnyVehicle(ped_s, false) then
-				local veh = GetVehiclePedIsUsing(ped_s)
-				SetLxSirenStateForVeh(veh, newstate)
+				local vehicle = GetVehiclePedIsUsing(ped_s)
+				SetLxSirenStateForVeh(vehicle, newstate)
 			end
 		end
 	end
@@ -535,8 +520,8 @@ AddEventHandler('lvc:SetPwrcallState_c', function(sender, newstate)
 	if DoesEntityExist(ped_s) and not IsEntityDead(ped_s) then
 		if ped_s ~= GetPlayerPed(-1) then
 			if IsPedInAnyVehicle(ped_s, false) then
-				local veh = GetVehiclePedIsUsing(ped_s)
-				SetPowercallStateForVeh(veh, newstate)
+				local vehicle = GetVehiclePedIsUsing(ped_s)
+				SetPowercallStateForVeh(vehicle, newstate)
 			end
 		end
 	end
@@ -550,8 +535,8 @@ AddEventHandler('lvc:SetAirManuState_c', function(sender, newstate)
 	if DoesEntityExist(ped_s) and not IsEntityDead(ped_s) then
 		if ped_s ~= GetPlayerPed(-1) then
 			if IsPedInAnyVehicle(ped_s, false) then
-				local veh = GetVehiclePedIsUsing(ped_s)
-				SetAirManuStateForVeh(veh, newstate)
+				local vehicle = GetVehiclePedIsUsing(ped_s)
+				SetAirManuStateForVeh(vehicle, newstate)
 			end
 		end
 	end


### PR DESCRIPTION
Hey there! 

Just added a few pieces of code to the `cl_lvc.lua`
#### Affected lines: 
```
381-390
416-424
443-451
470-478
```
(These lines are exact repeats of each other)

The purpose of these lines is that it adds a third party export so developers can utilize Luxart data such as power call states, etc. in their own scripts. 

## Event Details:
- Name: `lvc:updateThirdParty`
- Passed Data: `Array` (See breakdown below)

Breakdown of passed data:
Param Name | Data | Options
|------|-------|-------
| `state_lxsiren` | The LX siren state | `0`: Off, `2`: Wail, `3`: Yelp, `4`: T3/Prio 
| `state_indic` | The state of the vehicles indicators | `0`: Both off, `1`: Left on, `2`: Right on, `3`: Both on
| `state_pwrcall` | The power call state |  `0`: Off, `2`: Wail, `3`: Yelp, `4`: T3/Prio 
| `state_airmanu` | The airhorn manual state | `0`: Off, `1`: On
| `actv_manu` | Is manual siren on? | `true`, `false`
| `actv_horn` | Is the horn on? | `true`, `false`