### PR TITLE
Add control_lights_switch to config for compatibility

### DIFF
--- a/SETTINGS.lua
+++ b/SETTINGS.lua
@@ -48,6 +48,9 @@ custom_aux_tones_master_switch = true
 main_siren_set_register_keys_set_defaults = true
 --	Enables RegisterKeyMapping for all main_allowed_tones and sets the default keys to numrow 1-0.
 
+----------------LIGHTS / R* SIRENS-----------------
+control_lights_switch = true
+-- Enables control of emergency lights (R* sirens) with Q key. When disabled, allows for other resource to manage emergency lights state. (default: true)
 
 --------------TURN SIGNALS / HAZARDS---------------
 hazard_key = 202	

--- a/UTIL/cl_lvc.lua
+++ b/UTIL/cl_lvc.lua
@@ -552,7 +552,20 @@ CreateThread(function()
 
 			--- IS EMERG VEHICLE ---
 			if GetVehicleClass(veh) == 18 then
+
+				-- handle (R* Sirens) state on UI
+				if not lights_on and IsVehicleSirenOn(veh) then
+					-- SET NUI IMAGES
+					HUD:SetItemState('switch', true)
+				elseif lights_on and not IsVehicleSirenOn(veh) then
+					-- SET NUI IMAGES
+					HUD:SetItemState('switch', false)
+					HUD:SetItemState('siren', false)
+				end
+				
+				-- get new lights (R* Sirens) state
 				lights_on = IsVehicleSirenOn(veh)
+
 				--  FORCE RADIO ENABLED PER FRAME
 				if radio_masterswitch then
 					SetVehicleRadioEnabled(veh, true)
@@ -589,12 +602,9 @@ CreateThread(function()
 					if not IsPauseMenuActive() and UpdateOnscreenKeyboard() ~= 0 and not radio_wheel_active then
 						if not key_lock then
 							------ TOG DFLT SRN LIGHTS ------
-							if IsDisabledControlJustReleased(0, 85) then
+							if IsDisabledControlJustReleased(0, 85) and (control_lights_switch == nil or control_lights_switch) then
 								if lights_on then
 									AUDIO:Play('Off', AUDIO.off_volume)
-									--	SET NUI IMAGES
-									HUD:SetItemState('switch', false)
-									HUD:SetItemState('siren', false)
 									--	TURN OFF SIRENS (R* LIGHTS)
 									SetVehicleSiren(veh, false)
 									if trailer ~= nil and trailer ~= 0 then
@@ -603,8 +613,6 @@ CreateThread(function()
 
 								else
 									AUDIO:Play('On', AUDIO.on_volume) -- On
-									--	SET NUI IMAGES
-									HUD:SetItemState('switch', true)
 									--	TURN OFF SIRENS (R* LIGHTS)
 									SetVehicleSiren(veh, true)
 									if trailer ~= nil and trailer ~= 0 then


### PR DESCRIPTION
👋🏼 Hi, I've made a small change for compatibility with other resources. I have a resource which works well alongside this resource, but I would like to expand it to be able to control the state of the lights/R* sirens (the actual state of emergency lights being on or off).

Adding a switch in config that can disable control of lights with Q key in this resource will allow other resource to manage the state of the emergency lights instead.

I made an adjustment to how the UI is updated to reflect the state of the lights so that it is still responsive if another resource is controlling the lights.

- Add config value ``control_lights_switch = true`` to enable control of lights (R* sirens) with Q key with default of true (current behavior)
  - Added a check for nil, so if user does not add the switch value to their ``SETTINGS.lua`` it will still default to current behavior
- Move handling of lights state on UI so it is still responsive if lights are controlled by another resource
- Add check for switch

_Note: I was only able to test this on the most recent release, I was not sure how to package the development branch for testing._