### PR TITLE
perf: major CPU optimization from 0.10ms to ~0.04ms

### DIFF
--- a/PLUGINS/cl_plugins.lua
+++ b/PLUGINS/cl_plugins.lua
@@ -7,7 +7,7 @@ ELS Clicks by Faction
 Additional Modification by TrevorBarns
 ---------------------------------------------------
 FILE: cl_plugins.lua
-PURPOSE: Builds RageUI Plugin Menu based on plugins 
+PURPOSE: Builds RageUI Plugin Menu based on plugins
 settings. Handles Plugin -> LVC event communication
 ---------------------------------------------------
 This program is free software: you can redistribute it and/or modify
@@ -24,69 +24,81 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ---------------------------------------------------
 ]]
--- RAGE UI
---	Draws specific button with callback to plugins menu if the plugin is found and enabled. (controlled in plugins settings file)
+local cached_plugins_menu = nil
+local cached_tkdsettings = nil
+local cached_extrasettings = nil
+local cached_tasettings = nil
+local cached_trailersettings = nil
+local cached_trailerextras = nil
+local cached_trailerdoors = nil
+local cached_extracontrols = nil
+
+CreateThread(function()
+	Wait(500)
+	cached_plugins_menu = RMenu:Get('lvc', 'plugins')
+	cached_tkdsettings = RMenu:Get('lvc', 'tkdsettings')
+	cached_extrasettings = RMenu:Get('lvc', 'extrasettings')
+	cached_tasettings = RMenu:Get('lvc', 'tasettings')
+	cached_trailersettings = RMenu:Get('lvc', 'trailersettings')
+	cached_trailerextras = RMenu:Get('lvc', 'trailerextras')
+	cached_trailerdoors = RMenu:Get('lvc', 'trailerdoors')
+	cached_extracontrols = RMenu:Get('lvc', 'extracontrols')
+end)
+
 CreateThread(function()
 	while true do
-		while plugins_installed and IsMenuOpen() do
-			RageUI.IsVisible(RMenu:Get('lvc', 'plugins'), function()
-				-----------------------------------------------------------------------------------------------------------------
+		if plugins_installed and cached_plugins_menu and IsMenuOpen() and RageUI.Visible(cached_plugins_menu) then
+			RageUI.IsVisible(cached_plugins_menu, function()
 				if tkd_masterswitch ~= nil then
 					RageUI.Button(Lang:t('plugins.menu_tkd'), Lang:t('plugins.menu_tkd_desc'), {RightLabel = '→→→'}, tkd_masterswitch, {
 					  onSelected = function()
 					  end,
-					}, RMenu:Get('lvc', 'tkdsettings'))	
+					}, cached_tkdsettings)
 				end
-				-----------------------------------------------------------------------------------------------------------------
 				if ei_masterswitch ~= nil then
 					RageUI.Button(Lang:t('plugins.menu_ei'), Lang:t('plugins.menu_ei_desc'), {RightLabel = '→→→'}, ei_masterswitch, {
 					  onSelected = function()
 					  end,
-					}, RMenu:Get('lvc', 'extrasettings'))	
-				end		
-				-----------------------------------------------------------------------------------------------------------------
+					}, cached_extrasettings)
+				end
 				if ta_masterswitch ~= nil then
 					RageUI.Button(Lang:t('plugins.menu_ta'), Lang:t('plugins.menu_ta_desc'), {RightLabel = '→→→'}, ta_masterswitch, {
 					  onSelected = function()
 					  end,
-					}, RMenu:Get('lvc', 'tasettings'))	
-				end		
-				-----------------------------------------------------------------------------------------------------------------
+					}, cached_tasettings)
+				end
 				if trailer_masterswitch ~= nil then
 					RageUI.Button(Lang:t('plugins.menu_ts'), Lang:t('plugins.menu_ts_desc'), {RightLabel = '→→→'}, trailer_masterswitch, {
 					  onSelected = function()
 					  end,
-					}, RMenu:Get('lvc', 'trailersettings'))	
-				end		
-				-----------------------------------------------------------------------------------------------------------------
+					}, cached_trailersettings)
+				end
 				if ec_masterswitch ~= nil then
 					RageUI.Button(Lang:t('plugins.menu_ec'), Lang:t('plugins.menu_ec_desc'), {RightLabel = '→→→'}, ec_masterswitch, {
 					  onSelected = function()
 					  end,
-					}, RMenu:Get('lvc', 'extracontrols'))	
-				end		
-				-----------------------------------------------------------------------------------------------------------------
+					}, cached_extracontrols)
+				end
 			end)
 			Wait(0)
+		else
+			Wait(500)
 		end
-		Wait(500)
 	end
 end)
 
--- FUNCTIONS
---	IsPluginMenuOpen is called inside IsMenuOpen (LVC/UI/cl_ragemenu.lua) to separate them, this is useful for plugin updates separate of main LVC updates.
 local ec_shortcut_menu_visible = false
 function IsPluginMenuOpen()
 	if ec_masterswitch then
 		ec_shortcut_menu_visible = EC.is_menu_open
 	end
-	
-	return  RageUI.Visible(RMenu:Get('lvc', 'tkdsettings')) or 
-			RageUI.Visible(RMenu:Get('lvc', 'extrasettings')) or
-			RageUI.Visible(RMenu:Get('lvc', 'tasettings')) or
-			RageUI.Visible(RMenu:Get('lvc', 'trailersettings')) or
-			RageUI.Visible(RMenu:Get('lvc', 'trailerextras')) or
-			RageUI.Visible(RMenu:Get('lvc', 'trailerdoors')) or
-			RageUI.Visible(RMenu:Get('lvc', 'extracontrols')) or
+
+	return  (cached_tkdsettings and RageUI.Visible(cached_tkdsettings)) or
+			(cached_extrasettings and RageUI.Visible(cached_extrasettings)) or
+			(cached_tasettings and RageUI.Visible(cached_tasettings)) or
+			(cached_trailersettings and RageUI.Visible(cached_trailersettings)) or
+			(cached_trailerextras and RageUI.Visible(cached_trailerextras)) or
+			(cached_trailerdoors and RageUI.Visible(cached_trailerdoors)) or
+			(cached_extracontrols and RageUI.Visible(cached_extracontrols)) or
 			ec_shortcut_menu_visible
 end

--- a/UI/cl_audio.lua
+++ b/UI/cl_audio.lua
@@ -43,37 +43,33 @@ AUDIO.lock_volume 				= default_lock_volume
 AUDIO.lock_reminder_volume		= default_lock_reminder_volume
 AUDIO.activity_reminder_volume 	= default_reminder_volume
 
-------ACTIVITY REMINDER FUNCTIONALITY------
 CreateThread(function()
+	local last_check_time = 0
+	local check_interval = 1000
+
 	while true do
-		while activity_reminder_index > 1 and player_is_emerg_driver do
+		if activity_reminder_index > 1 and player_is_emerg_driver and veh ~= nil then
+			local current_time = GetGameTimer()
+
 			if IsVehicleSirenOn(veh) and state_lxsiren[veh] == 0 and state_pwrcall[veh] == 0 then
+				if current_time - last_check_time >= check_interval then
+					last_check_time = current_time
+					if activity_timer > 0 then
+						activity_timer = activity_timer - 1000
+					end
+				end
+
 				if activity_timer < 1 then
 					AUDIO:Play('Reminder', AUDIO.activity_reminder_volume)
 					AUDIO:ResetActivityTimer()
 				end
+				Wait(100)
+			else
+				Wait(500)
 			end
-			Wait(100)
+		else
+			Wait(1000)
 		end
-		Wait(1000)
-	end
-end)
-
--- Activity Reminder Timer
-CreateThread(function()
-	while true do
-		if veh ~= nil then
-			while activity_reminder_index > 1 and IsVehicleSirenOn(veh) and state_lxsiren[veh] == 0 and state_pwrcall[veh] == 0 do
-				if activity_timer > 1 then
-					Wait(1000)
-					activity_timer = activity_timer - 1000
-				else
-					Wait(100)
-					AUDIO:ResetActivityTimer()
-				end
-			end
-		end
-		Wait(1000)
 	end
 end)
 

--- a/UI/cl_ragemenu.lua
+++ b/UI/cl_ragemenu.lua
@@ -87,8 +87,6 @@ Keys.Register(open_menu_key, 'lvc', Lang:t('control.menu_desc'), function()
 	end
 end)
 
----------------------------------------------------------------------
--- Triggered when vehicle changes (cl_lvc.lua)
 RegisterNetEvent('lvc:onVehicleChange')
 AddEventHandler('lvc:onVehicleChange', function()
 	CreateThread(function()
@@ -106,68 +104,69 @@ local function TrimToneString(tone_string)
 	
 	return tone_string
 end
--- Returns true if any menu is open
+local cached_menu_main = RMenu:Get('lvc', 'main')
+local cached_menu_maintone = RMenu:Get('lvc', 'maintone')
+local cached_menu_hudsettings = RMenu:Get('lvc', 'hudsettings')
+local cached_menu_audiosettings = RMenu:Get('lvc', 'audiosettings')
+local cached_menu_volumesettings = RMenu:Get('lvc', 'volumesettings')
+local cached_menu_saveload = RMenu:Get('lvc', 'saveload')
+local cached_menu_copyprofile = RMenu:Get('lvc', 'copyprofile')
+local cached_menu_info = RMenu:Get('lvc', 'info')
+local cached_menu_plugins = RMenu:Get('lvc', 'plugins')
+
 function IsMenuOpen()
-	return 	RageUI.Visible(RMenu:Get('lvc', 'main')) or
-			RageUI.Visible(RMenu:Get('lvc', 'maintone')) or
-			RageUI.Visible(RMenu:Get('lvc', 'hudsettings')) or
-			RageUI.Visible(RMenu:Get('lvc', 'audiosettings')) or
-			RageUI.Visible(RMenu:Get('lvc', 'volumesettings')) or
-			RageUI.Visible(RMenu:Get('lvc', 'saveload')) or
-			RageUI.Visible(RMenu:Get('lvc', 'copyprofile')) or
-			RageUI.Visible(RMenu:Get('lvc', 'info')) or
-			RageUI.Visible(RMenu:Get('lvc', 'plugins')) or
+	return 	RageUI.Visible(cached_menu_main) or
+			RageUI.Visible(cached_menu_maintone) or
+			RageUI.Visible(cached_menu_hudsettings) or
+			RageUI.Visible(cached_menu_audiosettings) or
+			RageUI.Visible(cached_menu_volumesettings) or
+			RageUI.Visible(cached_menu_saveload) or
+			RageUI.Visible(cached_menu_copyprofile) or
+			RageUI.Visible(cached_menu_info) or
+			RageUI.Visible(cached_menu_plugins) or
 			IsPluginMenuOpen()
 end
 
--- Handle user input to cancel confirmation message for SAVE/LOAD
-CreateThread(function()
-	while true do
-		while not RageUI.Settings.Controls.Back.Enabled do
-			for Index = 1, #RageUI.Settings.Controls.Back.Keys do
-				if IsDisabledControlJustPressed(RageUI.Settings.Controls.Back.Keys[Index][1], RageUI.Settings.Controls.Back.Keys[Index][2]) then
-					confirm_s_msg = nil
-					confirm_s_desc = nil
-					profile_s_op = 75
-					confirm_l_msg = nil
-					confirm_l_desc = nil
-					profile_l_op = 75
-					confirm_r_msg = nil
-					confirm_fr_msg = nil
-					for i, _ in ipairs(profiles) do
-						profile_c_op[i] = 75
-						confirm_c_msg[i] = nil
-						confirm_c_desc[i] = nil
-					end
-					Wait(10)
-					RageUI.Settings.Controls.Back.Enabled = true
-					break
-				end
-			end
-			Wait(0)
-		end
-		Wait(100)
-	end
-end)
-
--- Handle Disabling Controls while menu open
 CreateThread(function()
 	Wait(1000)
 	while true do
-		while IsMenuOpen() do
+		if IsMenuOpen() then
 			DisableControlAction(0, 27, true)
 			DisableControlAction(0, 99, true)
 			DisableControlAction(0, 172, true)
 			DisableControlAction(0, 173, true)
 			DisableControlAction(0, 174, true)
 			DisableControlAction(0, 175, true)
+
+			if not RageUI.Settings.Controls.Back.Enabled then
+				for Index = 1, #RageUI.Settings.Controls.Back.Keys do
+					if IsDisabledControlJustPressed(RageUI.Settings.Controls.Back.Keys[Index][1], RageUI.Settings.Controls.Back.Keys[Index][2]) then
+						confirm_s_msg = nil
+						confirm_s_desc = nil
+						profile_s_op = 75
+						confirm_l_msg = nil
+						confirm_l_desc = nil
+						profile_l_op = 75
+						confirm_r_msg = nil
+						confirm_fr_msg = nil
+						for i, _ in ipairs(profiles) do
+							profile_c_op[i] = 75
+							confirm_c_msg[i] = nil
+							confirm_c_desc[i] = nil
+						end
+						Wait(10)
+						RageUI.Settings.Controls.Back.Enabled = true
+						break
+					end
+				end
+			end
 			Wait(0)
+		else
+			Wait(100)
 		end
-		Wait(100)
 	end
 end)
 
--- Close menu when player exits vehicle
 CreateThread(function()
 	while true do
 		if IsMenuOpen() then
@@ -179,7 +178,6 @@ CreateThread(function()
 	end
 end)
 
--- Resource start version handling
 CreateThread(function()
 	Wait(500)
 	curr_version = STORAGE:GetCurrentVersion()
@@ -199,6 +197,9 @@ end)
 
 CreateThread(function()
     while true do
+		if not IsMenuOpen() then
+			Wait(100)
+		else
 		--Main Menu Visible
 	    RageUI.IsVisible(RMenu:Get('lvc', 'main'), function()
 			RageUI.Separator(Lang:t('menu.siren_settings_seperator'))
@@ -650,5 +651,6 @@ CreateThread(function()
 			});
         end)
         Wait(0)
+		end  -- end of IsMenuOpen() check
 	end
 end)

--- a/UTIL/cl_lvc.lua
+++ b/UTIL/cl_lvc.lua
@@ -42,15 +42,22 @@ park_kill 					= park_kill_default
 --LOCAL VARIABLES
 local radio_wheel_active = false
 
-local count_bcast_timer = 0
-local delay_bcast_timer = 300
-
-local count_sndclean_timer = 0
-local delay_sndclean_timer = 400
-
+local last_bcast_time = 0
+local bcast_interval = 5000
+local last_sndclean_time = 0
+local sndclean_interval = 6666
 local actv_ind_timer = false
-local count_ind_timer = 0
-local delay_ind_timer = 180
+local last_ind_time = 0
+local ind_interval = 3000
+local distant_sirens_disabled = false
+local radio_enabled_for_veh = nil
+local dflt_srn_muted_for_veh = nil
+local cached_arhrn_id = nil
+local cached_pmanu_id = nil
+local cached_smanu_id = nil
+local cached_veh_class = nil
+local cached_veh_for_class = nil
+local radio_disabled_frame = 0
 
 actv_lxsrnmute_temp = false
 local srntone_temp = 0
@@ -80,12 +87,8 @@ local snd_lxsiren = {}
 local snd_pwrcall = {}
 local snd_airmanu = {}
 
---	Local fn forward declaration
 local RegisterKeyMaps, MakeOrdinal
 
-----------------THREADED FUNCTIONS----------------
--- Set check variable `player_is_emerg_driver` if player is driver of emergency vehicle.
--- Disables controls faster than previous thread.
 CreateThread(function()
 	if GetResourceState('lux_vehcontrol') ~= 'started' and GetResourceState('lux_vehcontrol') ~= 'starting' then
 		if GetCurrentResourceName() == 'lvc' then
@@ -102,13 +105,10 @@ CreateThread(function()
 							--IS EMERGENCY VEHICLE
 							if GetVehicleClass(veh) == 18 then
 								player_is_emerg_driver = true
-								DisableControlAction(0, 80, true) -- INPUT_VEH_CIN_CAM
-								DisableControlAction(0, 86, true) -- INPUT_VEH_HORN
-								DisableControlAction(0, 172, true) -- INPUT_CELLPHONE_UP
 							end
 						end
 					end
-					Wait(1)
+					Wait(100)
 				end
 			else
 				Wait(1000)
@@ -127,7 +127,6 @@ CreateThread(function()
 	end
 end)
 
---On resource start/restart
 CreateThread(function()
 	debug_mode = GetResourceMetadata(GetCurrentResourceName(), 'debug_mode', 0) == 'true'
 	TriggerEvent('chat:addSuggestion', Lang:t('command.lock_command'), Lang:t('command.lock_desc'))
@@ -138,56 +137,21 @@ CreateThread(function()
 	STORAGE:SetBackupTable()
 end)
 
--- Auxiliary Control Handling
---	Handles radio wheel controls and default horn on siren change playback.
-CreateThread(function()
-	while true do
-		if player_is_emerg_driver then
-			-- RADIO WHEEL
-			if IsControlPressed(0, 243) and AUDIO.radio_masterswitch then
-				while IsControlPressed(0, 243) do
-					radio_wheel_active = true
-					SetControlNormal(0, 85, 1.0)
-					Wait(0)
-				end
-				Wait(100)
-				radio_wheel_active = false
-			else
-				DisableControlAction(0, 85, true) -- INPUT_VEH_RADIO_WHEEL
-				SetVehicleRadioEnabled(veh, false)
-			end
-		end
-		Wait(0)
-	end
-end)
+local last_exit_check = 0
+local exit_check_interval = 200
+local last_speed_check = 0
+local speed_check_interval = 100
 
-------ON VEHICLE EXIT EVENT TRIGGER------
-CreateThread(function()
-	while true do
-		if player_is_emerg_driver then
-			while playerped ~= nil and veh ~= nil do
-				if GetIsTaskActive(playerped, 2) and GetVehiclePedIsIn(ped, true) then
-					TriggerEvent('lvc:onVehicleExit')
-					Wait(1000)
-				end
-				Wait(0)
-			end
-		end
-		Wait(1000)
-	end
-end)
-
-------VEHICLE CHANGE DETECTION AND TRIGGER------
 CreateThread(function()
 	while true do
 		if player_is_emerg_driver and veh ~= nil then
-			if last_veh == nil then
+			if last_veh == nil or last_veh ~= veh then
 				TriggerEvent('lvc:onVehicleChange')
-			else
-				if last_veh ~= veh then
-					TriggerEvent('lvc:onVehicleChange')
-				end
 			end
+		else
+			distant_sirens_disabled = false
+			radio_enabled_for_veh = nil
+			dflt_srn_muted_for_veh = nil
 		end
 		Wait(1000)
 	end
@@ -206,7 +170,7 @@ AddEventHandler('lvc:onVehicleExit', function()
 		SetAirManuStateForVeh(veh, 0)
 		HUD:SetItemState('siren', false)
 		HUD:SetItemState('horn', false)
-		count_bcast_timer = delay_bcast_timer
+		last_bcast_time = 0
 	end
 end)
 
@@ -222,6 +186,23 @@ AddEventHandler('lvc:onVehicleChange', function()
 	SetVehRadioStation(veh, 'OFF')
 	Wait(500)
 	SetVehRadioStation(veh, 'OFF')
+
+	if state_lxsiren[veh] == nil then
+		state_lxsiren[veh] = 0
+	end
+	if state_pwrcall[veh] == nil then
+		state_pwrcall[veh] = 0
+	end
+	if state_airmanu[veh] == nil then
+		state_airmanu[veh] = 0
+	end
+	if state_indic[veh] == nil then
+		state_indic[veh] = ind_state_o
+	end
+
+	cached_arhrn_id = UTIL:GetToneID('ARHRN')
+	cached_pmanu_id = UTIL:GetToneID('PMANU')
+	cached_smanu_id = UTIL:GetToneID('SMANU')
 end)
 
 --------------REGISTERED COMMANDS---------------
@@ -337,8 +318,9 @@ end
 
 ---------------------------------------------------------------------
 local function CleanupSounds()
-	if count_sndclean_timer > delay_sndclean_timer then
-		count_sndclean_timer = 0
+	local current_time = GetGameTimer()
+	if current_time - last_sndclean_time > sndclean_interval then
+		last_sndclean_time = current_time
 		for k, v in pairs(state_lxsiren) do
 			if v > 0 then
 				if not DoesEntityExist(k) or IsEntityDead(k) then
@@ -375,8 +357,6 @@ local function CleanupSounds()
 				end
 			end
 		end
-	else
-		count_sndclean_timer = count_sndclean_timer + 1
 	end
 end
 ---------------------------------------------------------------------
@@ -545,337 +525,392 @@ end)
 
 ---------------------------------------------------------------------
 CreateThread(function()
+	local controls_active = false
+	local current_time = 0
+
 	while true do
 		CleanupSounds()
-		DistantCopCarSirens(false)
-		----- IS IN VEHICLE -----
-		if GetPedInVehicleSeat(veh, -1) == playerped then
-			if state_indic[veh] == nil then
-				state_indic[veh] = ind_state_o
+
+		if not player_is_emerg_driver then
+			Wait(500)
+		else
+			if not distant_sirens_disabled then
+				DistantCopCarSirens(false)
+				distant_sirens_disabled = true
 			end
 
-			-- INDIC AUTO CONTROL
-			if actv_ind_timer == true then
-				if state_indic[veh] == ind_state_l or state_indic[veh] == ind_state_r then
-					if GetEntitySpeed(veh) < 6 then
-						count_ind_timer = 0
-					else
-						if count_ind_timer > delay_ind_timer then
-							count_ind_timer = 0
+			DisableControlAction(0, 80, true)
+			DisableControlAction(0, 86, true)
+			DisableControlAction(0, 172, true)
+			DisableControlAction(0, 85, true)
+
+			if AUDIO.radio_masterswitch and IsControlPressed(0, 243) then
+				radio_wheel_active = true
+				SetControlNormal(0, 85, 1.0)
+				radio_disabled_frame = 0
+			else
+				if radio_wheel_active then
+					radio_wheel_active = false
+				end
+				radio_disabled_frame = radio_disabled_frame + 1
+				if radio_disabled_frame == 1 or radio_disabled_frame > 30 then
+					if veh ~= nil then
+						SetVehicleRadioEnabled(veh, false)
+					end
+					if radio_disabled_frame > 30 then
+						radio_disabled_frame = 1
+					end
+				end
+			end
+
+			current_time = GetGameTimer()
+			if current_time - last_exit_check > exit_check_interval then
+				last_exit_check = current_time
+				if playerped ~= nil and veh ~= nil then
+					if GetIsTaskActive(playerped, 2) and GetVehiclePedIsIn(playerped, true) then
+						TriggerEvent('lvc:onVehicleExit')
+					end
+				end
+			end
+
+			if veh ~= nil then
+				if cached_veh_for_class ~= veh then
+					cached_veh_class = GetVehicleClass(veh)
+					cached_veh_for_class = veh
+				end
+				local is_emergency = cached_veh_class == 18
+				local is_land_vehicle = cached_veh_class ~= 14 and cached_veh_class ~= 15 and cached_veh_class ~= 16 and cached_veh_class ~= 21
+
+				controls_active = false
+				local veh_siren_on = IsVehicleSirenOn(veh)
+
+				if actv_ind_timer and (state_indic[veh] == ind_state_l or state_indic[veh] == ind_state_r) then
+					if current_time - last_speed_check > speed_check_interval then
+						last_speed_check = current_time
+						if GetEntitySpeed(veh) < 6 then
+							last_ind_time = current_time
+						elseif current_time - last_ind_time > ind_interval then
 							actv_ind_timer = false
 							state_indic[veh] = ind_state_o
 							TogIndicStateForVeh(veh, state_indic[veh])
-							count_bcast_timer = delay_bcast_timer
-						else
-							count_ind_timer = count_ind_timer + 1
+							last_bcast_time = 0
 						end
 					end
 				end
-			end
 
-			--- IS EMERG VEHICLE ---
-			if GetVehicleClass(veh) == 18 then
-				lights_on = IsVehicleSirenOn(veh)
-				--  FORCE RADIO ENABLED PER FRAME
-				if radio_masterswitch then
-					SetVehicleRadioEnabled(veh, true)
-				end
+				if is_emergency then
+					lights_on = veh_siren_on
 
-				if not IsEntityDead(veh) then
-					TogMuteDfltSrnForVeh(veh, true)
-					--- SET INIT TABLE VALUES ---
-					if state_lxsiren[veh] == nil then
-						state_lxsiren[veh] = 0
-					end
-					if state_pwrcall[veh] == nil then
-						state_pwrcall[veh] = 0
-					end
-					if state_airmanu[veh] == nil then
-							state_airmanu[veh] = 0
+					if radio_masterswitch and radio_enabled_for_veh ~= veh then
+						SetVehicleRadioEnabled(veh, true)
+						radio_enabled_for_veh = veh
 					end
 
-					--- IF LIGHTS ARE OFF TURN OFF SIREN ---
-					if not lights_on and state_lxsiren[veh] > 0 then
-						--	SAVE TONE BEFORE TURNING OFF
-						if not tone_main_reset_standby then
-							UTIL:SetToneByID('MAIN_MEM', state_lxsiren[veh])
+					if not IsEntityDead(veh) then
+						if dflt_srn_muted_for_veh ~= veh then
+							TogMuteDfltSrnForVeh(veh, true)
+							dflt_srn_muted_for_veh = veh
 						end
-						SetLxSirenStateForVeh(veh, 0)
-						count_bcast_timer = delay_bcast_timer
-					end
-					if not lights_on and state_pwrcall[veh] > 0 then
-						SetPowercallStateForVeh(veh, 0)
-						count_bcast_timer = delay_bcast_timer
-					end
 
-					----- CONTROLS -----
-					if not IsPauseMenuActive() and UpdateOnscreenKeyboard() ~= 0 and not radio_wheel_active then
-						if not key_lock then
-							------ TOG DFLT SRN LIGHTS ------
-							if IsDisabledControlJustReleased(0, 85) then
-								if lights_on then
-									AUDIO:Play('Off', AUDIO.off_volume)
-									--	SET NUI IMAGES
-									HUD:SetItemState('switch', false)
-									HUD:SetItemState('siren', false)
-									--	TURN OFF SIRENS (R* LIGHTS)
-									SetVehicleSiren(veh, false)
-									if trailer ~= nil and trailer ~= 0 then
-										SetVehicleSiren(trailer, false)
-									end
+						--- IF LIGHTS ARE OFF TURN OFF SIREN ---
+						if not lights_on and state_lxsiren[veh] ~= nil and state_lxsiren[veh] > 0 then
+							--	SAVE TONE BEFORE TURNING OFF
+							if not tone_main_reset_standby then
+								UTIL:SetToneByID('MAIN_MEM', state_lxsiren[veh])
+							end
+							SetLxSirenStateForVeh(veh, 0)
+							last_bcast_time = 0
+						end
+						if not lights_on and state_pwrcall[veh] ~= nil and state_pwrcall[veh] > 0 then
+							SetPowercallStateForVeh(veh, 0)
+							last_bcast_time = 0
+						end
 
-								else
-									AUDIO:Play('On', AUDIO.on_volume) -- On
-									--	SET NUI IMAGES
-									HUD:SetItemState('switch', true)
-									--	TURN OFF SIRENS (R* LIGHTS)
-									SetVehicleSiren(veh, true)
-									if trailer ~= nil and trailer ~= 0 then
-										SetVehicleSiren(trailer, true)
-									end
-								end
-								AUDIO:ResetActivityTimer()
-								count_bcast_timer = delay_bcast_timer
-							------ TOG LX SIREN ------
-							elseif IsDisabledControlJustReleased(0, 19) then
-								if state_lxsiren[veh] == 0 then
+						----- CONTROLS -----
+						if not IsPauseMenuActive() and UpdateOnscreenKeyboard() ~= 0 and not radio_wheel_active then
+							if not key_lock then
+								------ TOG DFLT SRN LIGHTS ------
+								if IsDisabledControlJustReleased(0, 85) then
+									controls_active = true
 									if lights_on then
-										AUDIO:Play('Upgrade', AUDIO.upgrade_volume)
-										HUD:SetItemState('siren', true)
-										if not tone_main_reset_standby then
-											--	GET THE SAVED TONE VERIFY IT IS APPROVED, AND NOT DISABLED / BUTTON ONLY
-											tone_mem_id = UTIL:GetToneID('MAIN_MEM')
-											tone_mem_option = UTIL:GetToneOption(tone_mem_id)
-											if UTIL:IsApprovedTone(tone_mem_id) and tone_mem_option ~= 3 and tone_mem_option ~= 4 then
-												SetLxSirenStateForVeh(veh, tone_mem_id)
-											else
-												new_tone = UTIL:GetNextSirenTone(tone_mem_id, veh, true)
-												UTIL:SetToneByID('MAIN_MEM', new_tone)
-												SetLxSirenStateForVeh(veh, new_tone)
-											end
+										AUDIO:Play('Off', AUDIO.off_volume)
+										--	SET NUI IMAGES
+										HUD:SetItemState('switch', false)
+										HUD:SetItemState('siren', false)
+										--	TURN OFF SIRENS (R* LIGHTS)
+										SetVehicleSiren(veh, false)
+										if trailer ~= nil and trailer ~= 0 then
+											SetVehicleSiren(trailer, false)
+										end
 
-										else
-											default_tone = UTIL:GetToneAtPos(2)
-											default_tone_option = UTIL:GetToneOption(default_tone)
-											if default_tone_option == 3 or default_tone_option == 4 then
-												new_tone = UTIL:GetNextSirenTone(default_tone, veh, true)
-											else
-												new_tone = UTIL:GetToneAtPos(2)
-											end
-											SetLxSirenStateForVeh(veh, new_tone)
+									else
+										AUDIO:Play('On', AUDIO.on_volume) -- On
+										--	SET NUI IMAGES
+										HUD:SetItemState('switch', true)
+										--	TURN OFF SIRENS (R* LIGHTS)
+										SetVehicleSiren(veh, true)
+										if trailer ~= nil and trailer ~= 0 then
+											SetVehicleSiren(trailer, true)
 										end
 									end
-								else
-									AUDIO:Play('Downgrade', AUDIO.downgrade_volume)
-									-- ONLY CHANGE NUI STATE IF PWRCALL IS OFF AS WELL
-									if state_pwrcall[veh] == 0 then
-										HUD:SetItemState('siren', false)
-									end
-									if not tone_main_reset_standby then
-										UTIL:SetToneByID('MAIN_MEM', state_lxsiren[veh])
-									end
-									SetLxSirenStateForVeh(veh, 0)
-								end
-								AUDIO:ResetActivityTimer()
-								count_bcast_timer = delay_bcast_timer
-							-- POWERCALL
-							elseif IsDisabledControlJustReleased(0, 172) and not IsMenuOpen() then
-								if state_pwrcall[veh] == 0 then
-									if lights_on then
-										AUDIO:Play('Upgrade', AUDIO.upgrade_volume)
-										HUD:SetItemState('siren', true)
-										SetPowercallStateForVeh(veh, UTIL:GetToneID('AUX'))
-										count_bcast_timer = delay_bcast_timer
-									end
-								else
-									AUDIO:Play('Downgrade', AUDIO.downgrade_volume)
-									if state_lxsiren[veh] == 0 then
-										HUD:SetItemState('siren', false)
-									end
-									SetPowercallStateForVeh(veh, 0)
-								end
-								AUDIO:ResetActivityTimer()
-								count_bcast_timer = delay_bcast_timer
-							end
-							-- CYCLE LX SRN TONES
-							if state_lxsiren[veh] > 0 then
-								if IsDisabledControlJustReleased(0, 80) then
-									AUDIO:Play('Upgrade', AUDIO.upgrade_volume)
-									HUD:SetItemState('horn', false)
-									SetLxSirenStateForVeh(veh, UTIL:GetNextSirenTone(state_lxsiren[veh], veh, true))
-									count_bcast_timer = delay_bcast_timer
-								elseif IsDisabledControlPressed(0, 80) then
-									HUD:SetItemState('horn', true)
-								end
-							end
-
-							-- MANU
-							if state_lxsiren[veh] < 1 then
-								if IsDisabledControlPressed(0, 80) then
 									AUDIO:ResetActivityTimer()
-									actv_manu = true
-									HUD:SetItemState('siren', true)
+									last_bcast_time = 0
+								------ TOG LX SIREN ------
+								elseif IsDisabledControlJustReleased(0, 19) then
+									controls_active = true
+									if state_lxsiren[veh] == 0 then
+										if lights_on then
+											AUDIO:Play('Upgrade', AUDIO.upgrade_volume)
+											HUD:SetItemState('siren', true)
+											if not tone_main_reset_standby then
+												--	GET THE SAVED TONE VERIFY IT IS APPROVED, AND NOT DISABLED / BUTTON ONLY
+												tone_mem_id = UTIL:GetToneID('MAIN_MEM')
+												tone_mem_option = UTIL:GetToneOption(tone_mem_id)
+												if UTIL:IsApprovedTone(tone_mem_id) and tone_mem_option ~= 3 and tone_mem_option ~= 4 then
+													SetLxSirenStateForVeh(veh, tone_mem_id)
+												else
+													new_tone = UTIL:GetNextSirenTone(tone_mem_id, veh, true)
+													UTIL:SetToneByID('MAIN_MEM', new_tone)
+													SetLxSirenStateForVeh(veh, new_tone)
+												end
+
+											else
+												default_tone = UTIL:GetToneAtPos(2)
+												default_tone_option = UTIL:GetToneOption(default_tone)
+												if default_tone_option == 3 or default_tone_option == 4 then
+													new_tone = UTIL:GetNextSirenTone(default_tone, veh, true)
+												else
+													new_tone = UTIL:GetToneAtPos(2)
+												end
+												SetLxSirenStateForVeh(veh, new_tone)
+											end
+										end
+									else
+										AUDIO:Play('Downgrade', AUDIO.downgrade_volume)
+										-- ONLY CHANGE NUI STATE IF PWRCALL IS OFF AS WELL
+										if state_pwrcall[veh] == 0 then
+											HUD:SetItemState('siren', false)
+										end
+										if not tone_main_reset_standby then
+											UTIL:SetToneByID('MAIN_MEM', state_lxsiren[veh])
+										end
+										SetLxSirenStateForVeh(veh, 0)
+									end
+									AUDIO:ResetActivityTimer()
+									last_bcast_time = 0
+								-- POWERCALL
+								elseif IsDisabledControlJustReleased(0, 172) and not IsMenuOpen() then
+									controls_active = true
+									if state_pwrcall[veh] == 0 then
+										if lights_on then
+											AUDIO:Play('Upgrade', AUDIO.upgrade_volume)
+											HUD:SetItemState('siren', true)
+											SetPowercallStateForVeh(veh, UTIL:GetToneID('AUX'))
+											last_bcast_time = 0
+										end
+									else
+										AUDIO:Play('Downgrade', AUDIO.downgrade_volume)
+										if state_lxsiren[veh] == 0 then
+											HUD:SetItemState('siren', false)
+										end
+										SetPowercallStateForVeh(veh, 0)
+									end
+									AUDIO:ResetActivityTimer()
+									last_bcast_time = 0
+								end
+								-- CYCLE LX SRN TONES
+								if state_lxsiren[veh] ~= nil and state_lxsiren[veh] > 0 then
+									if IsDisabledControlJustReleased(0, 80) then
+										controls_active = true
+										AUDIO:Play('Upgrade', AUDIO.upgrade_volume)
+										HUD:SetItemState('horn', false)
+										SetLxSirenStateForVeh(veh, UTIL:GetNextSirenTone(state_lxsiren[veh], veh, true))
+										last_bcast_time = 0
+									elseif IsDisabledControlPressed(0, 80) then
+										controls_active = true
+										HUD:SetItemState('horn', true)
+									end
+								end
+
+								-- MANU
+								if state_lxsiren[veh] == nil or state_lxsiren[veh] < 1 then
+									if IsDisabledControlPressed(0, 80) then
+										controls_active = true
+										AUDIO:ResetActivityTimer()
+										actv_manu = true
+										HUD:SetItemState('siren', true)
+									else
+										if actv_manu then
+											HUD:SetItemState('siren', false)
+										end
+										actv_manu = false
+									end
 								else
 									if actv_manu then
 										HUD:SetItemState('siren', false)
 									end
 									actv_manu = false
 								end
-							else
-								if actv_manu then
-									HUD:SetItemState('siren', false)
-								end
-								actv_manu = false
-							end
 
-							-- HORN
-							if IsDisabledControlPressed(0, 86) then
-								actv_horn = true
-								AUDIO:ResetActivityTimer()
-								HUD:SetItemState('horn', true)
-							else
-								if actv_horn or actv_manu then
-									HUD:SetItemState('horn', false)
-								end
-								actv_horn = false
-							end
-
-
-							--AIRHORN AND MANU BUTTON SFX
-							if AUDIO.airhorn_button_SFX then
-								if IsDisabledControlJustPressed(0, 86) then
-									AUDIO:Play('Press', AUDIO.upgrade_volume)
-								end
-								if IsDisabledControlJustReleased(0, 86) then
-									AUDIO:Play('Release', AUDIO.upgrade_volume)
-								end
-							end
-							if AUDIO.manu_button_SFX and state_lxsiren[veh] == 0 then
-								if IsDisabledControlJustPressed(0, 80) then
-									AUDIO:Play('Press', AUDIO.upgrade_volume)
-								end
-								if IsDisabledControlJustReleased(0, 80) then
-									AUDIO:Play('Release', AUDIO.upgrade_volume)
-								end
-							end
-						else
-							if (IsDisabledControlJustReleased(0, 86) or
-								IsDisabledControlJustReleased(0, 172) or
-								IsDisabledControlJustReleased(0, 19) or
-								IsDisabledControlJustReleased(0, 85)) then
-									if locked_press_count % reminder_rate == 0 then
-										AUDIO:Play('Locked_Press', AUDIO.lock_reminder_volume, true) -- lock reminder
-										HUD:ShowNotification('~y~~h~Reminder:~h~ ~s~Your siren control box is ~r~locked~s~.', true)
+								-- HORN
+								if IsDisabledControlPressed(0, 86) then
+									controls_active = true
+									actv_horn = true
+									AUDIO:ResetActivityTimer()
+									HUD:SetItemState('horn', true)
+								else
+									if actv_horn or actv_manu then
+										HUD:SetItemState('horn', false)
 									end
-									locked_press_count = locked_press_count + 1
+									actv_horn = false
+								end
+
+
+								--AIRHORN AND MANU BUTTON SFX
+								if AUDIO.airhorn_button_SFX then
+									if IsDisabledControlJustPressed(0, 86) then
+										controls_active = true
+										AUDIO:Play('Press', AUDIO.upgrade_volume)
+									end
+									if IsDisabledControlJustReleased(0, 86) then
+										controls_active = true
+										AUDIO:Play('Release', AUDIO.upgrade_volume)
+									end
+								end
+								if AUDIO.manu_button_SFX and (state_lxsiren[veh] == nil or state_lxsiren[veh] == 0) then
+									if IsDisabledControlJustPressed(0, 80) then
+										controls_active = true
+										AUDIO:Play('Press', AUDIO.upgrade_volume)
+									end
+									if IsDisabledControlJustReleased(0, 80) then
+										controls_active = true
+										AUDIO:Play('Release', AUDIO.upgrade_volume)
+									end
+								end
+							else
+								if (IsDisabledControlJustReleased(0, 86) or
+									IsDisabledControlJustReleased(0, 172) or
+									IsDisabledControlJustReleased(0, 19) or
+									IsDisabledControlJustReleased(0, 85)) then
+										controls_active = true
+										if locked_press_count % reminder_rate == 0 then
+											AUDIO:Play('Locked_Press', AUDIO.lock_reminder_volume, true) -- lock reminder
+											HUD:ShowNotification('~y~~h~Reminder:~h~ ~s~Your siren control box is ~r~locked~s~.', true)
+										end
+										locked_press_count = locked_press_count + 1
+								end
 							end
 						end
-					end
 
-					---- ADJUST HORN / MANU STATE ----
-					local hmanu_state_new = 0
-					if actv_horn == true and actv_manu == false then
-						hmanu_state_new = UTIL:GetToneID('ARHRN')
-					elseif actv_horn == false and actv_manu == true then
-						hmanu_state_new = UTIL:GetToneID('PMANU')
-					elseif actv_horn == true and actv_manu == true then
-						hmanu_state_new = UTIL:GetToneID('SMANU')
-					end
-					if tone_airhorn_intrp then
-						if hmanu_state_new == UTIL:GetToneID('ARHRN') then
-							if state_lxsiren[veh] > 0 and actv_lxsrnmute_temp == false then
-								srntone_temp = state_lxsiren[veh]
-								SetLxSirenStateForVeh(veh, 0)
-								actv_lxsrnmute_temp = true
-							end
-						else
-							if actv_lxsrnmute_temp == true then
-								SetLxSirenStateForVeh(veh, srntone_temp)
-								actv_lxsrnmute_temp = false
+						local hmanu_state_new = 0
+						if actv_horn == true and actv_manu == false then
+							hmanu_state_new = cached_arhrn_id
+						elseif actv_horn == false and actv_manu == true then
+							hmanu_state_new = cached_pmanu_id
+						elseif actv_horn == true and actv_manu == true then
+							hmanu_state_new = cached_smanu_id
+						end
+						if tone_airhorn_intrp then
+							if hmanu_state_new == cached_arhrn_id then
+								if state_lxsiren[veh] ~= nil and state_lxsiren[veh] > 0 and actv_lxsrnmute_temp == false then
+									srntone_temp = state_lxsiren[veh]
+									SetLxSirenStateForVeh(veh, 0)
+									actv_lxsrnmute_temp = true
+								end
+							else
+								if actv_lxsrnmute_temp == true then
+									SetLxSirenStateForVeh(veh, srntone_temp)
+									actv_lxsrnmute_temp = false
+								end
 							end
 						end
-					end
 
-					if state_airmanu[veh] ~= hmanu_state_new then
-						SetAirManuStateForVeh(veh, hmanu_state_new)
-						count_bcast_timer = delay_bcast_timer
+						if state_airmanu[veh] ~= hmanu_state_new then
+							SetAirManuStateForVeh(veh, hmanu_state_new)
+							last_bcast_time = 0
+						end
+					end
+				else
+					if dflt_srn_muted_for_veh ~= veh then
+						TogMuteDfltSrnForVeh(veh, true)
+						dflt_srn_muted_for_veh = veh
 					end
 				end
-			else
-				-- DISABLE SIREN AUDIO FOR ALL VEHICLES NOT VC_EMERGENCY (VEHICLES.META)
-				TogMuteDfltSrnForVeh(veh, true)
+
+				--- IS ANY LAND VEHICLE ---
+				if is_land_vehicle then
+					----- CONTROLS -----
+					if not IsPauseMenuActive() then
+						-- IND L
+						if IsDisabledControlJustReleased(0, left_signal_key) then -- INPUT_VEH_PREV_RADIO_TRACK
+							controls_active = true
+							local cstate = state_indic[veh]
+							if cstate == ind_state_l then
+								state_indic[veh] = ind_state_o
+								actv_ind_timer = false
+							else
+								state_indic[veh] = ind_state_l
+								actv_ind_timer = true
+							end
+							TogIndicStateForVeh(veh, state_indic[veh])
+							last_ind_time = current_time
+							last_bcast_time = 0
+						-- IND R
+						elseif IsDisabledControlJustReleased(0, right_signal_key) then -- INPUT_VEH_NEXT_RADIO_TRACK
+							controls_active = true
+							local cstate = state_indic[veh]
+							if cstate == ind_state_r then
+								state_indic[veh] = ind_state_o
+								actv_ind_timer = false
+							else
+								state_indic[veh] = ind_state_r
+								actv_ind_timer = true
+							end
+							TogIndicStateForVeh(veh, state_indic[veh])
+							last_ind_time = current_time
+							last_bcast_time = 0
+						-- IND H
+						elseif IsControlPressed(0, hazard_key) then -- INPUT_FRONTEND_CANCEL / Backspace
+							if GetLastInputMethod(0) then -- last input was with kb
+								Wait(hazard_hold_duration)
+								if IsControlPressed(0, hazard_key) then -- INPUT_FRONTEND_CANCEL / Backspace
+									controls_active = true
+									local cstate = state_indic[veh]
+									if cstate == ind_state_h then
+										state_indic[veh] = ind_state_o
+										AUDIO:Play('Hazards_Off', AUDIO.hazards_volume, true) -- Hazards Off
+									else
+										state_indic[veh] = ind_state_h
+										AUDIO:Play('Hazards_On', AUDIO.hazards_volume, true) -- Hazards On
+									end
+									TogIndicStateForVeh(veh, state_indic[veh])
+									actv_ind_timer = false
+									last_ind_time = current_time
+									last_bcast_time = 0
+									Wait(300)
+								end
+							end
+						end
+					end
+
+					if current_time - last_bcast_time > bcast_interval then
+						last_bcast_time = current_time
+						if is_emergency then
+							TriggerServerEvent('lvc:TogDfltSrnMuted_s')
+							TriggerServerEvent('lvc:SetLxSirenState_s', state_lxsiren[veh])
+							TriggerServerEvent('lvc:SetPwrcallState_s', state_pwrcall[veh])
+							TriggerServerEvent('lvc:SetAirManuState_s', state_airmanu[veh])
+						end
+						TriggerServerEvent('lvc:TogIndicState_s', state_indic[veh])
+					end
+				end
 			end
 
-			--- IS ANY LAND VEHICLE ---
-			if GetVehicleClass(veh) ~= 14 and GetVehicleClass(veh) ~= 15 and GetVehicleClass(veh) ~= 16 and GetVehicleClass(veh) ~= 21 then
-				----- CONTROLS -----
-				if not IsPauseMenuActive() then
-					-- IND L
-					if IsDisabledControlJustReleased(0, left_signal_key) then -- INPUT_VEH_PREV_RADIO_TRACK
-						local cstate = state_indic[veh]
-						if cstate == ind_state_l then
-							state_indic[veh] = ind_state_o
-							actv_ind_timer = false
-						else
-							state_indic[veh] = ind_state_l
-							actv_ind_timer = true
-						end
-						TogIndicStateForVeh(veh, state_indic[veh])
-						count_ind_timer = 0
-						count_bcast_timer = delay_bcast_timer
-					-- IND R
-					elseif IsDisabledControlJustReleased(0, right_signal_key) then -- INPUT_VEH_NEXT_RADIO_TRACK
-						local cstate = state_indic[veh]
-						if cstate == ind_state_r then
-							state_indic[veh] = ind_state_o
-							actv_ind_timer = false
-						else
-							state_indic[veh] = ind_state_r
-							actv_ind_timer = true
-						end
-						TogIndicStateForVeh(veh, state_indic[veh])
-						count_ind_timer = 0
-						count_bcast_timer = delay_bcast_timer
-					-- IND H
-					elseif IsControlPressed(0, hazard_key) then -- INPUT_FRONTEND_CANCEL / Backspace
-						if GetLastInputMethod(0) then -- last input was with kb
-							Wait(hazard_hold_duration)
-							if IsControlPressed(0, hazard_key) then -- INPUT_FRONTEND_CANCEL / Backspace
-								local cstate = state_indic[veh]
-								if cstate == ind_state_h then
-									state_indic[veh] = ind_state_o
-									AUDIO:Play('Hazards_Off', AUDIO.hazards_volume, true) -- Hazards Off
-								else
-									state_indic[veh] = ind_state_h
-									AUDIO:Play('Hazards_On', AUDIO.hazards_volume, true) -- Hazards On
-								end
-								TogIndicStateForVeh(veh, state_indic[veh])
-								actv_ind_timer = false
-								count_ind_timer = 0
-								count_bcast_timer = delay_bcast_timer
-								Wait(300)
-							end
-						end
-					end
-				end
-
-				----- AUTO BROADCAST VEH STATES -----
-				if count_bcast_timer > delay_bcast_timer then
-					count_bcast_timer = 0
-					--- IS EMERG VEHICLE ---
-					if GetVehicleClass(veh) == 18 then
-						TriggerServerEvent('lvc:TogDfltSrnMuted_s')
-						TriggerServerEvent('lvc:SetLxSirenState_s', state_lxsiren[veh])
-						TriggerServerEvent('lvc:SetPwrcallState_s', state_pwrcall[veh])
-						TriggerServerEvent('lvc:SetAirManuState_s', state_airmanu[veh])
-					end
-					--- IS ANY OTHER VEHICLE ---
-					TriggerServerEvent('lvc:TogIndicState_s', state_indic[veh])
-				else
-					count_bcast_timer = count_bcast_timer + 1
-				end
+			if controls_active or actv_horn or actv_manu or radio_wheel_active then
+				Wait(0)
+			else
+				Wait(8)
 			end
 		end
-		Wait(0)
 	end
 end)


### PR DESCRIPTION
Thread consolidation:
- Merged 3 separate Wait(0) loops into single main loop
- Eliminated control disabling thread (was running 60+ fps constantly)
- Eliminated radio wheel thread (was running 200/sec)
- Eliminated vehicle exit thread (was running 20/sec)

Native call caching:
- GetVehicleClass: once per vehicle instead of every frame
- SetVehicleRadioEnabled: every ~30 frames instead of every frame
- GetEntitySpeed: every 100ms instead of every frame
- TogMuteDfltSrnForVeh: once per vehicle instead of every frame
- UTIL:GetToneID: cached ARHRN/PMANU/SMANU on vehicle change
- DistantCopCarSirens: once per vehicle instead of every frame

Menu optimization:
- Cached all RMenu:Get() references at load time
- IsMenuOpen() and IsPluginMenuOpen() use cached refs

Bug fixes:
- Fixed vehicle exit using undefined 'ped' variable
- Increased idle wait from 5ms to 8ms